### PR TITLE
星たちのパーツ構成の再考

### DIFF
--- a/Defs/Bodies/BodieDef_star.xml
+++ b/Defs/Bodies/BodieDef_star.xml
@@ -8,21 +8,13 @@
     parts の木構造は以下の通り
       RTTS_BodyPart_WorkableStar_Torso [胸部]
         ├── RTTS_BodyPart_WorkableStar_Edge [頭部]
-        │   ├── SightSensor [視覚センサー]
-        │   ├── SightSensor [視覚センサー]
-        │   ├── HearingSensor [聴覚センサー]
-        │   ├── HearingSensor [聴覚センサー]
-        │   └── SmellSensor [嗅覚センサー]
         ├── RTTS_BodyPart_WorkableStar_Edge [前左翼]
         ├── RTTS_BodyPart_WorkableStar_Edge [前右翼]
         ├── RTTS_BodyPart_WorkableStar_Edge [後左翼]
         ├── RTTS_BodyPart_WorkableStar_Edge [後右翼]
         └── RTTS_BodyPart_WorkableStar_ArmoredBox [隔壁内部]
-            ├── ArtificialBrain [人工脳]
-            ├── RTTS_BodyPart_WorkableStar_levitator [浮力発生装置(移動用)]
-            ├── RTTS_BodyPart_WorkableStar_telekinesis [テレキネシス装置(作業用)]
-            ├── Reactor [リアクター(心臓相当)]
-            └── FluidReprocessor (x2) [流体再処理装置(肝臓相当)]
+          └── RTTS_BodyPart_WorkableStar_ArmoredBox [隔壁内部]
+            └── RTTS_BodyPart_WorkableStar_core [重要パーツ]
   -->
   <BodyDef>
     <defName>RTTS_Mech_Body_WorkableStar</defName>
@@ -40,32 +32,7 @@
           <customLabel>head edge</customLabel>
           <coverage>0.12</coverage>
           <height>Top</height>
-          <parts>
-            <li>
-              <def>SightSensor</def>
-              <customLabel>left sight sensor</customLabel>
-              <coverage>0.13</coverage>
-            </li>
-            <li>
-              <def>SightSensor</def>
-              <customLabel>right sight sensor</customLabel>
-              <coverage>0.13</coverage>
-            </li>
-            <li>
-              <def>HearingSensor</def>
-              <customLabel>left hearing sensor</customLabel>
-              <coverage>0.10</coverage>
-            </li>
-            <li>
-              <def>HearingSensor</def>
-              <customLabel>right hearing sensor</customLabel>
-              <coverage>0.10</coverage>
-            </li>
-            <li>
-              <def>SmellSensor</def>
-              <coverage>0.10</coverage>
-            </li>
-          </parts>
+          <depth>Outside</depth>
         </li>
         <li>
           <def>RTTS_BodyPart_WorkableStar_Edge</def>
@@ -111,34 +78,17 @@
           <coverage>0.39</coverage>
           <parts>
             <li>
-              <def>ArtificialBrain</def>
-              <coverage>0.20</coverage>
+              <def>RTTS_BodyPart_WorkableStar_ArmoredBox</def>
+              <coverage>0.30</coverage>
+              <customLabel>armored box inside</customLabel>
               <depth>Inside</depth>
-            </li>
-            <li>
-              <def>RTTS_BodyPart_WorkableStar_levitator</def>
-              <coverage>0.10</coverage>
-              <depth>Inside</depth>
-            </li>
-            <li>
-              <def>RTTS_BodyPart_WorkableStar_telekinesis</def>
-              <coverage>0.10</coverage>
-              <depth>Inside</depth>
-            </li>
-            <li>
-              <def>Reactor</def>
-              <coverage>0.10</coverage>
-              <depth>Inside</depth>
-            </li>
-            <li>
-              <def>FluidReprocessor</def>
-              <coverage>0.10</coverage>
-              <depth>Inside</depth>
-            </li>
-            <li>
-              <def>FluidReprocessor</def>
-              <coverage>0.10</coverage>
-              <depth>Inside</depth>
+              <parts>
+                <li>
+                  <def>RTTS_BodyPart_WorkableStar_core</def>
+                  <coverage>0.30</coverage>
+                  <depth>Inside</depth>
+                </li>
+              </parts>
             </li>
           </parts>
         </li>

--- a/Defs/Bodies/BodiePartDef.xml
+++ b/Defs/Bodies/BodiePartDef.xml
@@ -6,6 +6,7 @@
     <defName>RTTS_BodyPart_WorkableStar_Edge</defName>
     <label>edge</label>
     <hitPoints>50</hitPoints> <!-- MechanicalLeg(30) + MechanicalFoot(20) -->
+    <frostbiteVulnerability>2</frostbiteVulnerability>
     <permanentInjuryChanceFactor>0</permanentInjuryChanceFactor>
     <destroyableByDamage>false</destroyableByDamage>
     <skinCovered>false</skinCovered>
@@ -39,36 +40,6 @@
     <bleedRate>0</bleedRate>
   </BodyPartDef>
 
-  <!-- 移動用の浮力発生パーツ、タグ以外のステータスについてはリアクターに準拠 -->
-  <BodyPartDef>
-    <defName>RTTS_BodyPart_WorkableStar_levitator</defName>
-    <label>levitator</label>
-    <hitPoints>20</hitPoints>
-    <permanentInjuryChanceFactor>0</permanentInjuryChanceFactor>
-    <skinCovered>false</skinCovered>
-    <solid>true</solid>
-    <alive>false</alive>
-    <bleedRate>0</bleedRate>
-    <tags>
-      <li>MovingLimbCore</li>
-    </tags>
-  </BodyPartDef>
-
-  <!-- 作業用の念力発生パーツ、タグ以外のステータスについてはリアクターに準拠 -->
-  <BodyPartDef>
-    <defName>RTTS_BodyPart_WorkableStar_telekinesis</defName>
-    <label>telekinesis generator</label>
-    <hitPoints>20</hitPoints>
-    <permanentInjuryChanceFactor>0</permanentInjuryChanceFactor>
-    <skinCovered>false</skinCovered>
-    <solid>true</solid>
-    <alive>false</alive>
-    <bleedRate>0</bleedRate>
-    <tags>
-      <li>ManipulationLimbCore</li>
-    </tags>
-  </BodyPartDef>
-
   <!-- 攻撃用のパーツ -->
   <BodyPartDef>
     <defName>RTTS_BodyPart_WorkableStar_twinkle</defName>
@@ -81,6 +52,27 @@
     <bleedRate>0</bleedRate>
     <tags>
       <li>ManipulationLimbCore</li>
+    </tags>
+  </BodyPartDef>
+
+  <BodyPartDef>
+    <!-- 星の核、センサーやらリアクターやら全部のせ -->
+    <defName>RTTS_BodyPart_WorkableStar_core</defName>
+    <label>core</label>
+    <hitPoints>150</hitPoints> <!-- タグ付きパーツ全部のせでだいたいこんぐらいになるはず  -->
+    <permanentInjuryChanceFactor>0</permanentInjuryChanceFactor>
+    <skinCovered>false</skinCovered>
+    <solid>true</solid>
+    <alive>false</alive>
+    <bleedRate>0</bleedRate>
+    <tags>
+      <li>SightSource</li> <!-- 視覚 -->
+      <li>HearingSource</li> <!-- 聴覚 -->
+      <li>ManipulationLimbCore</li> <!-- 操作用 -->
+      <li>MovingLimbCore</li> <!-- 移動用 -->
+      <li>ConsciousnessSource</li> <!-- 意識 -->
+      <li>BloodPumpingSource</li> <!-- 血液ポンプ -->
+      <li>BloodFiltrationSource</li> <!-- 血液ろ過 -->
     </tags>
   </BodyPartDef>
 

--- a/Defs/ThingDef/jet_star.xml
+++ b/Defs/ThingDef/jet_star.xml
@@ -14,7 +14,7 @@
       \n\n&lt;color=#808080&gt;EnabledWork: Firefighter, BasicWorker, Hauling&lt;/color&gt;</description>
 
     <statBases>
-      <MarketValue>4240</MarketValue> <!-- 市場価値 -->
+      <MarketValue>5000</MarketValue> <!-- 市場価値 -->
       <MoveSpeed>8.00</MoveSpeed> <!-- 移動速度, 8.0を超えると経路計算的な負荷が上がるという話を何処かで見聞きしている -->
 
       <!-- 許容温度設定 -->

--- a/Defs/ThingDef/work_star_abstract.xml
+++ b/Defs/ThingDef/work_star_abstract.xml
@@ -3,7 +3,7 @@
   <!-- 作業用メカノイド群の共通定義 -->
   <ThingDef Abstract="True" Name="RTTS_Mech_work_star" ParentName="RTTS_Mech_star">
     <statBases>
-      <MarketValue>1120</MarketValue> <!-- 市場価値 -->
+      <MarketValue>1500</MarketValue> <!-- 市場価値 -->
       <MoveSpeed>6.00</MoveSpeed> <!-- 移動速度, 8.0を超えると経路計算的な負荷が上がるという話を何処かで見聞きしている -->
 
       <!-- 許容温度設定 -->

--- a/Languages/Japanese (日本語)/DefInjected/BodyDef/BodieDef_star.xml
+++ b/Languages/Japanese (日本語)/DefInjected/BodyDef/BodieDef_star.xml
@@ -5,16 +5,6 @@
   <RTTS_Mech_Body_WorkableStar.label>ワークブルスターのボディ</RTTS_Mech_Body_WorkableStar.label>
   <!-- EN: head edge -->
   <RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.customLabel>頭(角)</RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.customLabel>
-  <!-- EN: left sight sensor -->
-  <RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.left_sight_sensor.customLabel>左視覚センサー</RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.left_sight_sensor.customLabel>
-  <!-- EN: right sight sensor -->
-  <RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.right_sight_sensor.customLabel>右視覚センサー</RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.right_sight_sensor.customLabel>
-  <!-- EN: left hearing sensor -->
-  <RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.left_hearing_sensor.customLabel>
-    左聴覚センサー</RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.left_hearing_sensor.customLabel>
-  <!-- EN: right hearing sensor -->
-  <RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.right_hearing_sensor.customLabel>
-    右聴覚センサー</RTTS_Mech_Body_WorkableStar.corePart.parts.head_edge.parts.right_hearing_sensor.customLabel>
   <!-- EN: front left edge -->
   <RTTS_Mech_Body_WorkableStar.corePart.parts.front_left_edge.customLabel>前左角</RTTS_Mech_Body_WorkableStar.corePart.parts.front_left_edge.customLabel>
   <!-- EN: front right edge -->
@@ -23,5 +13,7 @@
   <RTTS_Mech_Body_WorkableStar.corePart.parts.rear_left_edge.customLabel>後左角</RTTS_Mech_Body_WorkableStar.corePart.parts.rear_left_edge.customLabel>
   <!-- EN: rear right edge -->
   <RTTS_Mech_Body_WorkableStar.corePart.parts.rear_right_edge.customLabel>後右角</RTTS_Mech_Body_WorkableStar.corePart.parts.rear_right_edge.customLabel>
+  <!-- EN: armored box inside -->
+  <RTTS_Mech_Body_WorkableStar.corePart.parts.RTTS_BodyPart_WorkableStar_ArmoredBox.parts.armored_box_inside.customLabel>多重隔壁(内)</RTTS_Mech_Body_WorkableStar.corePart.parts.RTTS_BodyPart_WorkableStar_ArmoredBox.parts.armored_box_inside.customLabel>
 
 </LanguageData>

--- a/Languages/Japanese (日本語)/DefInjected/BodyPartDef/BodiePartDef.xml
+++ b/Languages/Japanese (日本語)/DefInjected/BodyPartDef/BodiePartDef.xml
@@ -4,14 +4,11 @@
   <!-- EN: armored box -->
   <RTTS_BodyPart_WorkableStar_ArmoredBox.label>装甲ボックス</RTTS_BodyPart_WorkableStar_ArmoredBox.label>
 
+  <!-- EN: core -->
+  <RTTS_BodyPart_WorkableStar_core.label>星の核</RTTS_BodyPart_WorkableStar_core.label>
+
   <!-- EN: edge -->
   <RTTS_BodyPart_WorkableStar_Edge.label>角</RTTS_BodyPart_WorkableStar_Edge.label>
-
-  <!-- EN: levitator -->
-  <RTTS_BodyPart_WorkableStar_levitator.label>浮力発生装置</RTTS_BodyPart_WorkableStar_levitator.label>
-
-  <!-- EN: telekinesis generator -->
-  <RTTS_BodyPart_WorkableStar_telekinesis.label>念動力発生器</RTTS_BodyPart_WorkableStar_telekinesis.label>
 
   <!-- EN: torso -->
   <RTTS_BodyPart_WorkableStar_Torso.label>胴体</RTTS_BodyPart_WorkableStar_Torso.label>

--- a/Languages/Japanese (日本語)/DefInjected/ThingDef/jet_star.xml
+++ b/Languages/Japanese (日本語)/DefInjected/ThingDef/jet_star.xml
@@ -3,8 +3,7 @@
 
   <!-- EN: jet star -->
   <RTTS_Mech_jet_star.label>ジェットスター</RTTS_Mech_jet_star.label>
-  <!-- EN: Mechanoid for Hauling and Melee Fighting. Has Shield, Has Emp Melee Attack.\n
-  \n\n<color=#808080>EnabledWork: Firefighter, BasicWorker, Hauling</color> -->
+  <!-- EN: Mechanoid for Hauling and Melee Fighting. Has Shield, Has Emp Melee Attack.\n      \n\n<color=#808080>EnabledWork: Firefighter, BasicWorker, Hauling</color> -->
   <RTTS_Mech_jet_star.description>運搬や近接戦闘用のメカノイド。シールドとEMP近接攻撃を持つ。\n\n&lt;color=#808080&gt;有効作業：消火、雑用、運搬&lt;/color&gt;</RTTS_Mech_jet_star.description>
   <!-- EN: twinkle -->
   <RTTS_Mech_jet_star.tools.twinkle.label>キラキラ</RTTS_Mech_jet_star.tools.twinkle.label>


### PR DESCRIPTION
- 新パーツ 星の核 を追加
- 星の核 を 二重隔壁の内側に配置
- 星の核 で不要になった既存のセンサーパーツ等を除去
- "凍傷を受ける場所がない" と エラーが出たので角が凍えるようにした
- 市場価格をアップ